### PR TITLE
fix: markdown images overflowing on mobile

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -52,3 +52,11 @@
     background-image: linear-gradient(to bottom, var(--color-neutral-900), var(--color-raisin));
   } */
 }
+
+@layer base {
+  article img,
+  .prose img {
+    max-width: 100%;
+    height: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- constrain markdown-rendered images so they no longer overflow on small screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f2149ff88331834a507891ef51a5)